### PR TITLE
Improved chat commands parsing.

### DIFF
--- a/EssentialsPlugin/Core.cs
+++ b/EssentialsPlugin/Core.cs
@@ -926,6 +926,53 @@ namespace EssentialsPlugin
 
 		#endregion
 
+		#region Private Methods
+		private string[] GetCommandParts(string message)
+		{
+			bool quote = false;
+			List<string> commandParts = new List<string>();
+			string part = string.Empty;
+
+			for (int pos = 0; pos < message.Length; pos++)
+			{
+				char character = message[pos];
+
+				if (character == '"')
+				{
+					if (!quote)
+					{
+						quote = true;
+					}
+					else if (quote && pos + 1 < message.Length && message[pos + 1] == '"')
+					{
+						part += character;
+						pos++;
+					}
+					else
+					{
+						quote = false;
+					}
+				}
+				else if (character == ' ' && !quote)
+				{
+					commandParts.Add(part);
+					part = string.Empty;
+				}
+				else
+				{
+					part += character;
+				}
+			}
+
+			if (!quote && part.Length > 0)
+			{
+				commandParts.Add(part);
+			}
+
+			return commandParts.ToArray();
+		}
+		#endregion
+
 		#region Processing Loop
 		private void PluginProcessing()
 		{
@@ -1058,7 +1105,7 @@ namespace EssentialsPlugin
 		{
 			// Parse chat message
 			ulong remoteUserId = steamId;
-			string[] commandParts = message.Split(' ');
+			string[] commandParts = GetCommandParts(message);
 
 			// User wants some help
 			if (commandParts[0].ToLower() == "/help")


### PR DESCRIPTION
Allowing using double quotes to set commands parameters with spaces.
eg: /admin move player position "John Doe" 100 100 100

Use double quotes twice in order to set include a double quote in the parameter.
eg: /admin move player position "John""Doe" 100 100 100 (for player John"Doe)