### PR TITLE
New commands parser implications.

### DIFF
--- a/EssentialsPlugin/ChatHandlers/Admin/HandleAdminTurrets.cs
+++ b/EssentialsPlugin/ChatHandlers/Admin/HandleAdminTurrets.cs
@@ -38,8 +38,7 @@ namespace EssentialsPlugin.ChatHandlers
 
 		public override bool HandleCommand(ulong userId, string[] words)
 		{
-			string[] splits = General.SplitString(string.Join(" ", words));
-			if (splits.Length != 1)
+			if (words.Length != 1)
 			{
 				Communication.SendPrivateInformation(userId, GetHelp());
 				return true;
@@ -82,7 +81,7 @@ namespace EssentialsPlugin.ChatHandlers
 						IMyEntity turret = block.FatBlock;
 						bool state = FunctionalBlockEntity.GetState(turret);
 
-						if(splits[0].ToLower() == "toggle")
+						if (words[0].ToLower() == "toggle")
 							FunctionalBlockEntity.SetState(turret, !state);
 
 						count++;
@@ -92,7 +91,7 @@ namespace EssentialsPlugin.ChatHandlers
 						else
 							disabled++;
 
-						if (splits[0].ToLower() == "test" && state)
+						if (words[0].ToLower() == "test" && state)
 						{
 							BoundingSphereD sphere = new BoundingSphereD(grid.GetPosition(), 2000);
 							List<IMyEntity> testEntities = MyAPIGateway.Entities.GetEntitiesInSphere(ref sphere);

--- a/EssentialsPlugin/ChatHandlers/HandleLastSeen.cs
+++ b/EssentialsPlugin/ChatHandlers/HandleLastSeen.cs
@@ -38,14 +38,13 @@ namespace EssentialsPlugin.ChatHandlers
 
 		public override bool HandleCommand(ulong userId, string[] words)
 		{
-			string[] splits = General.SplitString(string.Join(" ", words));
-			if (splits.Count() != 1)
+			if (words.Count() != 1)
 			{
 				Communication.SendPrivateInformation(userId, GetHelp());
 				return true;
 			}
 
-			string userName = splits[0];
+			string userName = words[0];
 			ulong steamId = PlayerMap.Instance.GetSteamIdFromPlayerName(userName, true);
 			if (steamId == 0)
 			{

--- a/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointAdd.cs
+++ b/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointAdd.cs
@@ -42,12 +42,9 @@
 		public override bool HandleCommand(ulong userId, string[] words)
 		{
 			if (!PluginSettings.Instance.WaypointsEnabled)
-				if (!PluginSettings.Instance.WaypointsEnabled)
 				return false;
-			
-			string[] splits = General.SplitString(string.Join(" ", words));
 
-			if (splits.Length != 6 && splits.Length != 7 && splits.Length != 5 && splits.Length != 1)
+			if (words.Length != 1 && words.Length != 5 && words.Length != 6 && words.Length != 7)
 			{
 				Communication.SendPrivateInformation(userId, GetHelp());
 				return true;
@@ -60,7 +57,7 @@
 				return true;
 			}
 
-			if (splits.Length == 1)
+			if (words.Length == 1)
 			{
 				long playerId = PlayerMap.Instance.GetFastPlayerIdFromSteamId(userId);
 				IMyEntity playerEntity = Player.FindControlledEntity(playerId);
@@ -71,9 +68,9 @@
 				}
 
 				Vector3D pos = playerEntity.GetPosition();
-				string name = splits[0];
+				string name = words[0];
 
-				Communication.SendClientMessage(userId, string.Format("/waypoint add \"{0}\" \"{0}\" Neutral {1} {2} {3}", name, Math.Floor(pos.X), Math.Floor(pos.Y), Math.Floor(pos.Z)));
+				Communication.SendClientMessage(userId, string.Format("/waypoint add '{0}' '{0}' Neutral {1} {2} {3}", name, Math.Floor(pos.X), Math.Floor(pos.Y), Math.Floor(pos.Z)));
 
 				WaypointItem item = new WaypointItem();
 				item.SteamId = userId;
@@ -83,53 +80,53 @@
 				item.WaypointType = WaypointTypes.Neutral;
 				Waypoints.Instance.Add(item);
 
-				Communication.SendPrivateInformation(userId, string.Format("Waypoint added: {0} at {1}", item.Name, General.Vector3DToString(item.Position)));
+				Communication.SendPrivateInformation(userId, string.Format("Waypoint added: '{0}' at {1}", item.Name, General.Vector3DToString(item.Position)));
 			}
 			else
 			{
 				int len = 5;
-				if (splits.Length > 5)
+				if (words.Length > 5)
 					len = 6;
 
 				for (int r = len - 3; r < len; r++)
 				{
 					double test = 0d;
-					if (!double.TryParse(splits[r], out test))
+					if (!double.TryParse(words[r], out test))
 					{
-						Communication.SendPrivateInformation(userId, string.Format("Invalid position information: {0} is invalid", splits[r]));
+						Communication.SendPrivateInformation(userId, string.Format("Invalid position information: {0} is invalid", words[r]));
 						return true;
 					}
 				}
 
 				string add = "";
-				foreach (string split in splits)
+				foreach (string word in words)
 				{
 					if (add == "")
-						add += split.ToLower();
+						add += word.ToLower();
 					else
-						add += " " + split;
+						add += " " + word;
 				}
 
 				Communication.SendClientMessage(userId, string.Format("/waypoint add {0}", add));
 
 				string group = "";
-				if (splits.Length == 7)
-					group = splits[7];
+				if (words.Length == 7)
+					group = words[7];
 
 				WaypointItem item = new WaypointItem();
 				item.SteamId = userId;
-				item.Name = splits[0];
+				item.Name = words[0];
 
-				int diff = splits.Length > 5 ? 1 : 0;
-				item.Text = splits[diff];
+				int diff = words.Length > 5 ? 1 : 0;
+				item.Text = words[diff];
 				WaypointTypes type = WaypointTypes.Neutral;
-				Enum.TryParse<WaypointTypes>(splits[diff + 1], true, out type);
+				Enum.TryParse<WaypointTypes>(words[diff + 1], true, out type);
 				item.WaypointType = type;
-				item.Position = new Vector3D(double.Parse(splits[diff + 2]), double.Parse(splits[diff + 3]), double.Parse(splits[diff + 4]));
+				item.Position = new Vector3D(double.Parse(words[diff + 2]), double.Parse(words[diff + 3]), double.Parse(words[diff + 4]));
 				item.Group = group;
 				Waypoints.Instance.Add(item);
 
-				Communication.SendPrivateInformation(userId, string.Format("Waypoint added: {0} at {1}", item.Name, General.Vector3DToString(item.Position)));
+				Communication.SendPrivateInformation(userId, string.Format("Waypoint added: '{0}' at {1}", item.Name, General.Vector3DToString(item.Position)));
 			}
 			return true;
 		}

--- a/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointFactionAdd.cs
+++ b/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointFactionAdd.cs
@@ -43,12 +43,9 @@
 		public override bool HandleCommand(ulong userId, string[] words)
 		{
 			if (!PluginSettings.Instance.WaypointsEnabled)
-				if (!PluginSettings.Instance.WaypointsEnabled)
 				return false;
-			
-			string[] splits = General.SplitString(string.Join(" ", words));
 
-			if (splits.Length != 6 && splits.Length != 7 && splits.Length != 1)
+			if (words.Length != 6 && words.Length != 7 && words.Length != 1)
 			{
 				Communication.SendPrivateInformation(userId, GetHelp());
 				return true;
@@ -70,7 +67,7 @@
 				return true;
 			}
 
-			if (splits.Length == 1)
+			if (words.Length == 1)
 			{
 				IMyEntity playerEntity = Player.FindControlledEntity(playerId);
 				if(playerEntity == null)
@@ -80,13 +77,13 @@
 				}
 
 				Vector3D pos = playerEntity.GetPosition();
-				string name = splits[0];
+				string name = words[0];
 
 				foreach (ulong steamId in PlayerManager.Instance.ConnectedPlayers)
 				{
 					if (Player.CheckPlayerSameFaction(userId, steamId))
 					{
-						Communication.SendClientMessage(steamId, string.Format("/waypoint add \"{0}\" \"{0}\" Neutral {1} {2} {3}", name, Math.Floor(pos.X), Math.Floor(pos.Y), Math.Floor(pos.Z)));
+						Communication.SendClientMessage(steamId, string.Format("/waypoint add '{0}' '{0}' Neutral {1} {2} {3}", name, Math.Floor(pos.X), Math.Floor(pos.Y), Math.Floor(pos.Z)));
 					}
 				}
 
@@ -101,21 +98,21 @@
 				                    };
 				Waypoints.Instance.Add(item);
 
-				Communication.SendFactionClientMessage(userId, string.Format("/message Server {2} has added the waypoint: {0} at {1} by {2}", item.Name, General.Vector3DToString(item.Position), playerName));
+				Communication.SendFactionClientMessage(userId, string.Format("/message Server {2} has added the waypoint: '{0}' at {1} by '{2}'", item.Name, General.Vector3DToString(item.Position), playerName));
 			}
 			else
 			{
 				for (int r = 3; r < 6; r++)
 				{
 					double test;
-					if (!double.TryParse(splits[r], out test))
+					if (!double.TryParse(words[r], out test))
 					{
-						Communication.SendPrivateInformation(userId, string.Format("Invalid position information: {0} is invalid", splits[r]));
+						Communication.SendPrivateInformation(userId, string.Format("Invalid position information: {0} is invalid", words[r]));
 						return true;
 					}
 				}
 
-				string add = string.Join( " ", splits.Select( s => s.ToLowerInvariant( ) ) );
+				string add = string.Join(" ", words.Select(s => s.ToLowerInvariant()));
 
 				foreach (ulong steamId in PlayerManager.Instance.ConnectedPlayers)
 				{
@@ -126,24 +123,24 @@
 				}
 
 				string group = "";
-				if (splits.Length == 7)
-					group = splits[7];
+				if (words.Length == 7)
+					group = words[7];
 
 				WaypointItem item = new WaypointItem
 				                    {
 					                    SteamId = (ulong) faction.FactionId,
-					                    Name = splits[ 0 ],
-					                    Text = splits[ 1 ]
+										Name = words[0],
+										Text = words[1]
 				                    };
 				WaypointTypes type;
-				Enum.TryParse(splits[2], true, out type);
+				Enum.TryParse(words[2], true, out type);
 				item.WaypointType = type;
-				item.Position = new Vector3D(double.Parse(splits[3]), double.Parse(splits[4]), double.Parse(splits[5]));
+				item.Position = new Vector3D(double.Parse(words[3]), double.Parse(words[4]), double.Parse(words[5]));
 				item.Group = group;
 				item.Leader = faction.IsLeader(playerId);
 				Waypoints.Instance.Add(item);
 
-				Communication.SendFactionClientMessage(userId, string.Format("/message Server {2} has added the waypoint: {0} at {1} by {2}", item.Name, General.Vector3DToString(item.Position), playerName));
+				Communication.SendFactionClientMessage(userId, string.Format("/message Server {2} has added the waypoint: '{0}' at {1} by '{2}'", item.Name, General.Vector3DToString(item.Position), playerName));
 			}
 			return true;
 		}

--- a/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointFactionRemove.cs
+++ b/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointFactionRemove.cs
@@ -43,9 +43,7 @@
 			if (!PluginSettings.Instance.WaypointsEnabled)
 				return false;
 
-			string[] splits = General.SplitString(string.Join(" ", words));
-
-			if (splits.Count() != 1)
+			if (words.Count() != 1)
 			{
 				Communication.SendPrivateInformation(userId, GetHelp());
 				return true;
@@ -61,39 +59,29 @@
 			}
 
 			List<WaypointItem> items = Waypoints.Instance.Get((ulong)faction.FactionId);
-			WaypointItem item = items.FirstOrDefault(x => x.Name.ToLower() == splits[0].ToLower());
+			WaypointItem item = items.FirstOrDefault(x => x.Name.ToLower() == words[0].ToLower());
 			if (item == null)
 			{
-				Communication.SendPrivateInformation(userId, string.Format("You do not have a faction waypoint with the name: {0}", splits[0]));
+				Communication.SendPrivateInformation(userId, string.Format("You do not have a faction waypoint with the name: {0}", words[0]));
 				return true;
 			}
 
 			if (item.Leader && !faction.IsLeader(playerId))
 			{
-				Communication.SendPrivateInformation(userId, string.Format("You must be a faction leader to remove the waypoint: {0}", splits[0]));
+				Communication.SendPrivateInformation(userId, string.Format("You must be a faction leader to remove the waypoint: {0}", words[0]));
 				return true;
 			}
 
-			Waypoints.Instance.Remove((ulong)faction.FactionId, splits[0]);
-
-			string remove = "";
-			foreach (string split in splits)
-			{
-				if (remove == "")
-					remove += split.ToLower();
-				else
-					remove += " " + split;
-			}
-
+			Waypoints.Instance.Remove((ulong)faction.FactionId, words[0]);
 			foreach (ulong steamId in PlayerManager.Instance.ConnectedPlayers)
 			{
 				if (Player.CheckPlayerSameFaction(userId, steamId))
 				{
-					Communication.SendClientMessage(steamId, string.Format("/waypoint remove {0}", remove));
+					Communication.SendClientMessage(steamId, string.Format("/waypoint remove '{0}'", words[0]));
 				}
 			}
 
-			Communication.SendFactionClientMessage(userId, string.Format("/message Server {0} has removed the waypoint: {1}", playerName, remove));
+			Communication.SendFactionClientMessage(userId, string.Format("/message Server {0} has removed the waypoint: '{1}'", playerName, words[0]));
 			return true;
 		}
 	}

--- a/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointGroupAdd.cs
+++ b/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointGroupAdd.cs
@@ -42,23 +42,21 @@
 		{
 			if (!PluginSettings.Instance.WaypointsEnabled)
 				return false;
-			
-			string[] splits = General.SplitString(string.Join(" ", words));
 
-			if (splits.Length != 2)
+			if (words.Length != 2)
 			{
 				Communication.SendPrivateInformation(userId, GetHelp());
 				return true;
 			}
 
-			string name = splits[0];
-			string group = splits[1];
+			string name = words[0];
+			string group = words[1];
 
 			List<WaypointItem> items = Waypoints.Instance.Get(userId);
-			WaypointItem item = items.FirstOrDefault(x => x.Name.ToLower() == splits[0]);
+			WaypointItem item = items.FirstOrDefault(x => x.Name.ToLower() == words[0]);
 			if (item != null)
 			{
-				if (Waypoints.Instance.GroupAdd(userId, splits[0], splits[1]))
+				if (Waypoints.Instance.GroupAdd(userId, words[0], words[1]))
 					Communication.SendPrivateInformation(userId, string.Format("Waypoint '{0}' added to the group '{1}'", name, group));
 				else
 					Communication.SendPrivateInformation(userId, string.Format("Failed to add waypoint '{0}' to the group '{1}'", name, group));
@@ -72,7 +70,7 @@
 			if (faction != null)
 			{
 				items = Waypoints.Instance.Get((ulong)faction.FactionId);
-				item = items.FirstOrDefault(x => x.Name.ToLower() == splits[0]);
+				item = items.FirstOrDefault(x => x.Name.ToLower() == words[0]);
 
 				if (item != null)
 				{
@@ -82,7 +80,7 @@
 						return true;
 					}
 
-					if (Waypoints.Instance.GroupAdd((ulong)faction.FactionId, splits[0], splits[1]))
+					if (Waypoints.Instance.GroupAdd((ulong)faction.FactionId, words[0], words[1]))
 						Communication.SendFactionClientMessage(userId, string.Format("/message Server {0} added the waypoint '{1}' to the group '{2}'", playerName, name, group));
 					else
 						Communication.SendPrivateInformation(userId, string.Format("Failed to add faction waypoint '{0}' to the group '{1}'", name, group));

--- a/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointGroupRemove.cs
+++ b/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointGroupRemove.cs
@@ -42,19 +42,17 @@
 		{
 			if (!PluginSettings.Instance.WaypointsEnabled)
 				return false;
-			
-			string[] splits = General.SplitString(string.Join(" ", words));
 
-			if (splits.Length != 1)
+			if (words.Length != 1)
 			{
 				Communication.SendPrivateInformation(userId, GetHelp());
 				return true;			
 			}
 
-			string name = splits[0];
+			string name = words[0];
 
 			List<WaypointItem> items = Waypoints.Instance.Get(userId);
-			WaypointItem item = items.FirstOrDefault(x => x.Name.ToLower() == splits[0]);
+			WaypointItem item = items.FirstOrDefault(x => x.Name.ToLower() == words[0]);
 			if (item != null)
 			{
 				if (Waypoints.Instance.GroupRemove(userId, name))
@@ -71,7 +69,7 @@
 			if (faction != null)
 			{
 				items = Waypoints.Instance.Get((ulong)faction.FactionId);
-				item = items.FirstOrDefault(x => x.Name.ToLower() == splits[0]);
+				item = items.FirstOrDefault(x => x.Name.ToLower() == words[0]);
 
 				if (item != null)
 				{

--- a/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointList.cs
+++ b/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointList.cs
@@ -55,9 +55,9 @@
 					waypoints += "\r\n";
 
 				if(item.Group != null && item.Group != "")
-					waypoints += string.Format("Group {3} - {0}: '{1}' : ({2})", item.Name, item.Text, General.Vector3DToString(item.Position), item.Group);
+					waypoints += string.Format("Group {3} - {0}: '{1}' : {2}", item.Name, item.Text, General.Vector3DToString(item.Position), item.Group);
 				else
-					waypoints += string.Format("{0}: '{1}' : ({2})", item.Name, item.Text, General.Vector3DToString(item.Position));
+					waypoints += string.Format("{0}: '{1}' : {2}", item.Name, item.Text, General.Vector3DToString(item.Position));
 			}
 			personalCount = items.Count;
 
@@ -75,9 +75,9 @@
 						waypoints += "\r\n";
 
 					if (item.Group != null && item.Group != "")
-						waypoints += string.Format("F: Group {3} - {0}: '{1}' : ({2})", item.Name, item.Text, General.Vector3DToString(item.Position), item.Group);
+						waypoints += string.Format("F: Group {3} - {0}: '{1}' : {2}", item.Name, item.Text, General.Vector3DToString(item.Position), item.Group);
 					else
-						waypoints += string.Format("F: {0}: '{1}' : ({2})", item.Name, item.Text, General.Vector3DToString(item.Position));
+						waypoints += string.Format("F: {0}: '{1}' : {2}", item.Name, item.Text, General.Vector3DToString(item.Position));
 				}
 
 				factionCount = items.Count;

--- a/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointRemove.cs
+++ b/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointRemove.cs
@@ -41,34 +41,22 @@
 			if (!PluginSettings.Instance.WaypointsEnabled)
 				return false;
 
-			string[] splits = General.SplitString(string.Join(" ", words));
-
-			if (splits.Count() != 1)
+			if (words.Count() != 1)
 			{
 				Communication.SendPrivateInformation(userId, GetHelp());
 				return true;
 			}
 
 			List<WaypointItem> items = Waypoints.Instance.Get(userId);
-			if (items.FirstOrDefault(x => x.Name.ToLower() == splits[0].ToLower()) == null)
+			if (items.FirstOrDefault(x => x.Name.ToLower() == words[0].ToLower()) == null)
 			{
-				Communication.SendPrivateInformation(userId, string.Format("You do not have a waypoint with the name: {0}", splits[0]));
+				Communication.SendPrivateInformation(userId, string.Format("You do not have a waypoint with the name: {0}", words[0]));
 				return true;
 			}
 
-			Waypoints.Instance.Remove(userId, splits[0]);
-
-			string remove = "";
-			foreach (string split in splits)
-			{
-				if (remove == "")
-					remove += split.ToLower();
-				else
-					remove += " " + split;
-			}
-
-			Communication.SendClientMessage(userId, string.Format("/waypoint remove {0}", remove));
-			Communication.SendPrivateInformation(userId, string.Format("Removed waypoint: {0}", splits[0]));
+			Waypoints.Instance.Remove(userId, words[0]);
+			Communication.SendClientMessage(userId, string.Format("/waypoint remove '{0}'", words[0]));
+			Communication.SendPrivateInformation(userId, string.Format("Removed waypoint: '{0}'", words[0]));
 			return true;
 		}
 	}

--- a/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointToggle.cs
+++ b/EssentialsPlugin/ChatHandlers/Waypoints/HandleWaypointToggle.cs
@@ -38,26 +38,24 @@
 		{
 			if (!PluginSettings.Instance.WaypointsEnabled)
 				return false;
-			
-			string[] splits = General.SplitString(string.Join(" ", words));
 
-			if (splits.Length > 0 && !Waypoints.Instance.GroupExists(userId, splits[0]))
+			if (words.Length > 0 && !Waypoints.Instance.GroupExists(userId, words[0]))
 			{
-				Communication.SendPrivateInformation(userId, string.Format("Group '{0}' does not exist.  You can only toggle a valid group", splits[0]));
+				Communication.SendPrivateInformation(userId, string.Format("Group '{0}' does not exist.  You can only toggle a valid group", words[0]));
 				return true;
 			}
 
-			if (splits.Length < 1)
+			if (words.Length < 1)
 				Waypoints.Instance.Toggle(userId);
 			else
-				Waypoints.Instance.Toggle(userId, splits[0]);
+				Waypoints.Instance.Toggle(userId, words[0]);
 
 			Waypoints.SendClientWaypoints(userId);
 
-			if (splits.Length < 1)
+			if (words.Length < 1)
 				Communication.SendPrivateInformation(userId, string.Format("Toggled all waypoints"));
 			else
-				Communication.SendPrivateInformation(userId, string.Format("Toggled waypoint group '{0}'", splits[0]));
+				Communication.SendPrivateInformation(userId, string.Format("Toggled waypoint group '{0}'", words[0]));
 
 			return true;
 		}

--- a/EssentialsPlugin/ProcessHandlers/ProcessCleanup.cs
+++ b/EssentialsPlugin/ProcessHandlers/ProcessCleanup.cs
@@ -7,6 +7,7 @@
 	using EssentialsPlugin.Utility;
 	using NLog;
 	using Sandbox.ModAPI;
+	using SEModAPI.API.Utility;
 
 	class ProcessCleanup : ProcessHandlerBase
 	{
@@ -63,7 +64,7 @@
 			if ( time - DateTime.Now < TimeSpan.FromSeconds( 1 ) && DateTime.Now - item.LastRan > TimeSpan.FromMinutes( 1 ) )
 			{
 				string command = item.ScanCommand + " quiet";
-				HashSet<IMyEntity> entities = CubeGrids.ScanGrids( 0, command.Split( ' ' ) );
+				HashSet<IMyEntity> entities = CubeGrids.ScanGrids( 0, CommandParser.GetCommandParts( command ).ToArray( ) );
 				CubeGrids.DeleteGrids( entities );
 				Communication.SendPublicInformation( string.Format( "[NOTICE]: Timed cleanup has run.  {0} entities removed.  Have a nice day.", entities.Count ) );
 				item.LastRan = DateTime.Now;
@@ -104,7 +105,7 @@
 				{
 					item.LastRan = DateTime.Now;
 					string command = item.ScanCommand + " quiet";
-					HashSet<IMyEntity> entities = CubeGrids.ScanGrids( 0, command.Split( ' ' ) );
+					HashSet<IMyEntity> entities = CubeGrids.ScanGrids(0, CommandParser.GetCommandParts( command ).ToArray( ) );
 					if ( entities.Count >= item.MaxCapacity )
 					{
 						Communication.SendPublicInformation( string.Format( "[NOTICE]: Cleanup triggered.  ({0} of {1}) triggered grids found.  Cleanup will run in {2} minutes.  Reason: {3}", entities.Count, item.MaxCapacity, item.MinutesAfterCapacity, item.Reason ) );
@@ -119,7 +120,7 @@
 				if ( DateTime.Now - item.LastRan > TimeSpan.FromMinutes( item.MinutesAfterCapacity ) )
 				{
 					string command = item.ScanCommand + " quiet";
-					HashSet<IMyEntity> entities = CubeGrids.ScanGrids( 0, command.Split( ' ' ) );
+					HashSet<IMyEntity> entities = CubeGrids.ScanGrids(0, CommandParser.GetCommandParts( command ).ToArray( ) );
 					CubeGrids.DeleteGrids( entities );
 					Communication.SendPublicInformation( string.Format( "[NOTICE]: Triggered cleanup has run.  {0} entities removed.  Have a nice day.", entities.Count ) );
 					_triggerdItem = null;

--- a/EssentialsPlugin/Utility/CubeGrid.cs
+++ b/EssentialsPlugin/Utility/CubeGrid.cs
@@ -479,10 +479,8 @@ namespace EssentialsPlugin.Utility
 			return entitiesFound;
 		}
 
-		public static HashSet<IMyEntity> ScanGrids( ulong userId, string[ ] wordsOld )
+		public static HashSet<IMyEntity> ScanGrids( ulong userId, string[ ] words )
 		{
-			string line = string.Join( " ", wordsOld );
-			string[ ] words = General.SplitString( line );
 			Dictionary<string, string> options = new Dictionary<string, string>( );
 
 			// 0 - ignore 1 - no 2 - yes

--- a/EssentialsPlugin/Utility/Utility.cs
+++ b/EssentialsPlugin/Utility/Utility.cs
@@ -87,15 +87,6 @@ namespace EssentialsPlugin.Utility
 
 			return dest;
 		}
-		public static string[] SplitString(string data)
-		{
-			var result = data.Split('"').Select((element, index) => index % 2 == 0  // If even index
-												 ? element.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)  // Split the item
-												 : new string[] { element })  // Keep the entire item					
-												 .SelectMany(element => element).ToList();
-
-			return result.ToArray();
-		}
 
 		public static void Update<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
 		{


### PR DESCRIPTION
Removed the calls to General.SplitString() in order to have a consistent and reliable commands parsing.

I tested it with most commands that can use composed names (player or ship names) and also with timed and triggered cleanups. Everything seems to be working fine!

On a side note: I hesitated to modify the ChatHandlerBase.HandleCommand() virtual method in order to take List<string> instead of string[] but as the commands and parameters should not be modified it's perhaps not worth the modifications.