### PR TITLE
Fix for issue #27

### DIFF
--- a/EssentialsPlugin/ProcessHandlers/ProcessCleanup.cs
+++ b/EssentialsPlugin/ProcessHandlers/ProcessCleanup.cs
@@ -55,7 +55,10 @@
 			_start = DateTime.Now; // this needs to be updated for each run so multi-day runtimes are handled properly
 
 			DateTime time = new DateTime( _start.Year, _start.Month, _start.Day, item.Restart.Hour, item.Restart.Minute, 0 );
-
+			if ( time - DateTime.Now < TimeSpan.FromSeconds( -20 ) )
+			{
+				time = new DateTime( _start.Year, _start.Month, _start.Day + 1, item.Restart.Hour, item.Restart.Minute, 0 );
+			}
 
 			if ( DateTime.Now - item.LastRan < TimeSpan.FromMinutes( 1 ) )
 				return;

--- a/EssentialsPlugin/ProcessHandlers/ProcessCleanup.cs
+++ b/EssentialsPlugin/ProcessHandlers/ProcessCleanup.cs
@@ -52,11 +52,10 @@
 		/// <exception cref="OverflowException"></exception>
 		private void ProcessTimedItem( SettingsCleanupTimedItem item )
 		{
+			_start = DateTime.Now; // this needs to be updated for each run so multi-day runtimes are handled properly
+
 			DateTime time = new DateTime( _start.Year, _start.Month, _start.Day, item.Restart.Hour, item.Restart.Minute, 0 );
-			if ( time - DateTime.Now < TimeSpan.FromSeconds( -20 ) )
-			{
-				time = new DateTime( _start.Year, _start.Month, _start.Day + 1, item.Restart.Hour, item.Restart.Minute, 0 );
-			}
+
 
 			if ( DateTime.Now - item.LastRan < TimeSpan.FromMinutes( 1 ) )
 				return;


### PR DESCRIPTION
Logic error occurred when _start is more than one day in the past, This has been corrected by setting _start at each invocation of the cleanup.