### PR TITLE
Make the DateFormat for backups editable

### DIFF
--- a/EssentialsPlugin/ChatHandlers/Admin/HandleAdminBackup.cs
+++ b/EssentialsPlugin/ChatHandlers/Admin/HandleAdminBackup.cs
@@ -27,7 +27,7 @@
 		public override bool HandleCommand(ulong userId, string[] words)
 		{
 			Communication.SendPrivateInformation(userId, string.Format("Creating a save game backup ..."));
-			Backup.Create(PluginSettings.Instance.BackupBaseDirectory, PluginSettings.Instance.BackupCreateSubDirectories, PluginSettings.Instance.BackupAsteroids, PluginSettings.Instance.BackupEssentials);
+			Backup.Create(PluginSettings.Instance.BackupBaseDirectory, PluginSettings.Instance.BackupCreateSubDirectories, PluginSettings.Instance.BackupDateFormat, PluginSettings.Instance.BackupDateFormatSubDirectory, PluginSettings.Instance.BackupAsteroids, PluginSettings.Instance.BackupEssentials);
 			Communication.SendPrivateInformation(userId, string.Format("Save game backup created"));
 			return true;
 		}

--- a/EssentialsPlugin/Essentials.cs
+++ b/EssentialsPlugin/Essentials.cs
@@ -331,6 +331,26 @@
 			set { PluginSettings.Instance.BackupCreateSubDirectories = value; }
 		}
 
+		[Category("Automated Backup")]
+		[Description("Date format to use for the backup file")]
+		[Browsable(true)]
+		[ReadOnly(false)]
+		public string BackupDateFormat
+		{
+			get { return PluginSettings.Instance.BackupDateFormat; }
+			set { PluginSettings.Instance.BackupDateFormat = value; }
+		}
+
+		[Category("Automated Backup")]
+		[Description("Date format to use for the subdirectory")]
+		[Browsable(true)]
+		[ReadOnly(false)]
+		public string BackupDateFormatSubDirectory
+		{
+			get { return PluginSettings.Instance.BackupDateFormatSubDirectory; }
+			set { PluginSettings.Instance.BackupDateFormatSubDirectory = value; }
+		}
+
 		[Category( "Automated Backup" )]
 		[Description( "Should backups be cleaned up after a certain period of time?" )]
 		[Browsable( true )]

--- a/EssentialsPlugin/ProcessHandlers/ProcessBackup.cs
+++ b/EssentialsPlugin/ProcessHandlers/ProcessBackup.cs
@@ -29,16 +29,8 @@
 							continue;
 
 						// On the minute
-						if (item.Hour == -1)
-						{
-							if (item.Minute == DateTime.Now.Minute)
-								Backup.Create(PluginSettings.Instance.BackupBaseDirectory, PluginSettings.Instance.BackupCreateSubDirectories, PluginSettings.Instance.BackupAsteroids, PluginSettings.Instance.BackupEssentials);
-						}
-						else
-						{
-							if (item.Hour == DateTime.Now.Hour && item.Minute == DateTime.Now.Minute)
-								Backup.Create(PluginSettings.Instance.BackupBaseDirectory, PluginSettings.Instance.BackupCreateSubDirectories, PluginSettings.Instance.BackupAsteroids, PluginSettings.Instance.BackupEssentials);
-						}
+						if (item.Minute == DateTime.Now.Minute && (item.Hour == -1 || item.Hour == DateTime.Now.Hour))
+								Backup.Create(PluginSettings.Instance.BackupBaseDirectory, PluginSettings.Instance.BackupCreateSubDirectories, PluginSettings.Instance.BackupDateFormat, PluginSettings.Instance.BackupDateFormatSubDirectory, PluginSettings.Instance.BackupAsteroids, PluginSettings.Instance.BackupEssentials);
 					}
 
 					// Cleanup Backups

--- a/EssentialsPlugin/Settings/PluginSettings.cs
+++ b/EssentialsPlugin/Settings/PluginSettings.cs
@@ -47,6 +47,8 @@
 		private MTObservableCollection<BackupItem> _backupItems;
 		private bool _backupCreateSubDirectories;
 		private string _backupBaseDirectory;
+		private string _backupDateFormat;
+		private string _backupDateFormatSubDirectory;
 		private bool _backupCleanup;
 		private int _backupCleanupTime;
 		private bool _backupAsteroids;
@@ -319,6 +321,26 @@
 				if (_backupBaseDirectory == "")
 					_backupBaseDirectory = MyFileSystem.UserDataPath + "\\Backup";
 
+				Save();
+			}
+		}
+
+		public string BackupDateFormat
+		{
+			get { return _backupDateFormat; }
+			set
+			{
+				_backupDateFormat = value;
+				Save();
+			}
+		}
+
+		public string BackupDateFormatSubDirectory
+		{
+			get { return _backupDateFormatSubDirectory; }
+			set
+			{
+				_backupDateFormatSubDirectory = value;
 				Save();
 			}
 		}
@@ -805,6 +827,9 @@
 			_restartTimeItems.CollectionChanged += ItemsCollectionChanged;
 			_backupItems.CollectionChanged += ItemsCollectionChanged;
 			_protectedItems.CollectionChanged += ItemsCollectionChanged;
+
+			_backupDateFormat = "yyyy-MM-dd_HH-mm";
+			_backupDateFormatSubDirectory = "yyyy-MM-dd";
 
 			_greetingMessage = "";
 

--- a/EssentialsPlugin/Utility/Backup.cs
+++ b/EssentialsPlugin/Utility/Backup.cs
@@ -7,7 +7,7 @@
 
 	static class Backup
 	{
-		static public void Create(string baseDirectory, bool createSubDirectories, bool backupAsteroids, bool backupSettings = false)
+		static public void Create(string baseDirectory, bool createSubDirectories, string dateFormat, string dateFormatSubDirectory, bool backupAsteroids, bool backupSettings = false)
 		{
 			Essentials.Log.Info( "Creating backup ..." );
 			//string baseDirectory = PluginSettings.Instance.BackupBaseDirectory;
@@ -22,7 +22,7 @@
 			//if (PluginSettings.Instance.BackupCreateSubDirectories)
 			if(createSubDirectories)
 			{
-				string subDirectory = string.Format("Backup-{0}", DateTime.Now.ToString("d-M-yyyy-HH-mm"));
+				string subDirectory = string.Format("Backup_{0}", DateTime.Now.ToString(dateFormatSubDirectory));
 				if (!Directory.Exists(baseDirectory + "\\" + subDirectory))
 					Directory.CreateDirectory(baseDirectory + "\\" + subDirectory);
 
@@ -64,14 +64,12 @@
 				}
 			}
 
-			ZipFile.CreateFromDirectory(tempDirectory, finalDirectory + "\\" + string.Format("Backup-{0}", DateTime.Now.ToString("d-M-yyyy-HH-mm")) + ".zip");
+			string fileName = string.Format("Backup_{0}.zip", DateTime.Now.ToString(dateFormat));
+			ZipFile.CreateFromDirectory(tempDirectory, finalDirectory + "\\" + fileName);
 
-			foreach (string file in Directory.GetFiles(tempDirectory))
-			{
-				File.Delete(file);
-			}
+			Directory.Delete(tempDirectory, true);
 
-			Essentials.Log.Info( "Backup created: {0}\\" + "Backup-{1}.zip", finalDirectory, DateTime.Now.ToString( "d-M-yyyy-hh-mm" ) );
+			Essentials.Log.Info( "Backup created: {0}\\{1}", finalDirectory, fileName );
 		}
 	}
 }


### PR DESCRIPTION
Use a sort friendly DateFormat by default
Remove the timestamp from the SubDirectory name
Refactor the ProcessBackup if-statement
Remove unnecessary DateTime.ToString duplication in Backup

